### PR TITLE
Perserve copyright notice for patch-package source

### DIFF
--- a/packages/plugin-patch/LICENSE
+++ b/packages/plugin-patch/LICENSE
@@ -1,0 +1,20 @@
+Original work Copyright (c) 2017 David Sheldrick
+Modified work Copyright (c) 2019 Maël Nison 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
**What's the problem this PR addresses?**

Given that this package copies and modifies a portion of [patch-package](https://github.com/ds300/patch-package)'s source, the copyright should be maintained in accordance with the MIT license.

**How did you fix it?**

Added a sublicense conforming to the MIT license of [patch-package](https://github.com/ds300/patch-package). 